### PR TITLE
🐛 Fixing reversing actions bug

### DIFF
--- a/safedown.go
+++ b/safedown.go
@@ -116,7 +116,7 @@ func (sa *ShutdownActions) shutdown() {
 		sa.mutex.Unlock()
 
 		if sa.order == FirstInLastDone {
-			for left, right := 0, len(sa.actions)-1; left < right; left, right = left+1, right-1 {
+			for left, right := 0, len(actions)-1; left < right; left, right = left+1, right-1 {
 				actions[left], actions[right] = actions[right], actions[left]
 			}
 		}


### PR DESCRIPTION
The length of `sa.actions` was taken instead of `actions`. This meant that if an action was added just before reversing then there may be an index out of range panic.

I can't think of how to create a test for this. It would require adding an action exactly before the actions are reversed.